### PR TITLE
Babel plugin-proposal-class-properties loose mode.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,13 @@
 {
   "presets": [
     ["babel-preset-gatsby-package"]
+  ],
+  "plugins": [
+    [
+      "@babel/plugin-proposal-class-properties",
+      {
+        "loose": true
+      }
+    ]
   ]
 }


### PR DESCRIPTION
Getting a build error for the plugin - gatsby-source-contentful/src/cache-image.js: 'loose' mode configuration must be the same for both @babel/plugin-proposal-class-properties and @babel/plugin-proposal-private-methods. Was able to reproduce it locally and fix by changing the babel config for the plugin, ref. [this post](https://stackoverflow.com/questions/52237855/support-for-the-experimental-syntax-classproperties-isnt-currently-enabled).